### PR TITLE
docs(readme): incluir 4 empresas com vagas de QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
-# Empresas que contratam pessoas desenvolvedoras junior e estagiárias
+# Empresas que contratam devs junior e para estágio
 
-Empresas que **constantemente** oferecem vagas para pessoas desenvolvedoras junior e estagiárias.
+Empresas que **constantemente** oferecem vagas para junior e para estagiários.
 
 ### Lembrem-se: junior é aquela pessoa que provavelmente NÃO tem experiência!
 
 ## Regras:
-- Só serão adicionadas na lista empresas que constantemente oferecem vagas para pessoas desenvolvedoras junior e estagiárias.
-- Serão **deletadas** da lista empresas que peçam experiência prévia para pessoas desenvolvedoras junior e estagiárias.
+- Só serão adicionadas na lista empresas que constantemente oferecem vagas para devs junior e para estagiários.
+- Serão **deletadas** da lista empresas que peçam experiência prévia para dev junior ou estagiário.
 - Só deve ser adicionado o link da **página das vagas da empresa**, e não da vaga.
+
+---
+
+- [Sambatech](https://jobs.kenoby.com/sambatech-carreiras/)
+- [Base2](https://jobs.solides.com/base2)
+- [Cognizant](https://careers.cognizant.com/br/pt)
+- [Zé Delivery](https://zedelivery.gupy.io/)


### PR DESCRIPTION
As 4 empresas inseridas são frequentes na divulgação de vagas de Júnior no repositório qa-brasil/vagas