### PR TITLE
docs(readme): incluir 4 empresas com vagas de QA

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,18 @@
+name: Check links
+
+on:
+  schedule:
+    - cron: "0 0/12 * * *"
+  workflow_dispatch:
+  push:
+  pull_request:
+
+jobs:
+  check-link:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Project checkout
+      uses: actions/checkout@v2
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/README.md
+++ b/README.md
@@ -8,3 +8,10 @@ Empresas que **constantemente** oferecem vagas para pessoas desenvolvedoras juni
 - Só serão adicionadas na lista empresas que constantemente oferecem vagas para pessoas desenvolvedoras junior e estagiárias.
 - Serão **deletadas** da lista empresas que peçam experiência prévia para pessoas desenvolvedoras junior e estagiárias.
 - Só deve ser adicionado o link da **página das vagas da empresa**, e não da vaga.
+
+---
+
+- [Sambatech](https://jobs.kenoby.com/sambatech-carreiras/)
+- [Base2](https://jobs.solides.com/base2)
+- [Cognizant](https://careers.cognizant.com/br/pt)
+- [Zé Delivery](https://zedelivery.gupy.io/)


### PR DESCRIPTION
As 4 empresas inseridas são frequentes na divulgação de vagas de Júnior no repositório qa-brasil/vagas

https://github.com/qa-brasil/vagas/issues?q=is%3Aopen+is%3Aissue+label%3AJ%C3%BAnior

---

Incluída action que vai validar se a cada _push_, _PR_ e de 12 em 12 horas se os links estão válidos.
