### PR TITLE
Update ReadMe.md - link quebrado

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,6 @@ Quando você for criar uma [issue](https://github.com/alinebastos/vagas-junior-e
 
 #### São Jose dos Campos - SP
 
-- [Buser](https://jobs.buser.com.br/apply/CEy9kt8P8m/Busercamp) e um bootcamp (remunerado, um dos disponiveis paga 3.500) fullstack que nao exige experiência em programação
-
 #### Sergipe - SE
 
 #### Tocantins - TO


### PR DESCRIPTION
# Origem

Build

# Problema

Link quebrado reportado no build do github

# Solução

Remover link quebrado do Readme.md, que estava causando [falha na build](https://user-images.githubusercontent.com/30783877/97216299-63b7d700-17a4-11eb-9709-20b80a0cd237.png)
